### PR TITLE
feat: add tavern:transport-closed event

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ tavern.js dispatches bubbling custom events for programmatic handling:
 | `tavern:recovering` | — | Transport open, recovery in progress |
 | `tavern:stream-degraded` | `{ tier, previousTier, topic, scope }` | Backpressure tier escalated (throttle, simplify, disconnect) |
 | `tavern:stream-restored` | `{ previousTier, topic, scope }` | Backpressure tier returned to normal |
+| `tavern:transport-open` | — | SSE transport reopened after a disconnect |
+| `tavern:transport-closed` | — | SSE transport dropped (raw transport fact, no UI implications) |
 
 ```javascript
 document.addEventListener("tavern:disconnected", (e) => {
@@ -238,6 +240,23 @@ All control events from the tavern broker now use structured JSON payloads.
 tavern.js parses these automatically and exposes the data as `detail` on the
 corresponding DOM events. Malformed or empty payloads are handled gracefully
 (detail defaults to an empty object).
+
+### Transport Signals
+
+`tavern:transport-open` and `tavern:transport-closed` are raw transport signals
+for diagnostics and shell-level indicators. They do not imply recovery state
+or trigger UI changes — use `tavern:disconnected` / `tavern:reconnected` for
+region-level state.
+
+```javascript
+// Shell-level connection indicator
+document.addEventListener("tavern:transport-closed", () => {
+  shellIndicator.classList.add("offline");
+});
+document.addEventListener("tavern:transport-open", () => {
+  shellIndicator.classList.remove("offline");
+});
+```
 
 ## Commands
 

--- a/src/tavern.js
+++ b/src/tavern.js
@@ -597,6 +597,15 @@
 
     // HTMX SSE lifecycle events
     el.addEventListener("htmx:sseError", function () {
+      // Raw transport signal — fires only if a connection was previously
+      // established (state is not "connecting").  Symmetric companion to
+      // tavern:transport-open.
+      if (el._tavernRegionState !== "connecting") {
+        el.dispatchEvent(
+          new CustomEvent("tavern:transport-closed", { bubbles: true }),
+        );
+      }
+
       markDisconnected(el, config);
 
       // Scoped stream fallback logic — only act if this element still owns the scope

--- a/test/tavern.test.js
+++ b/test/tavern.test.js
@@ -2429,6 +2429,90 @@ describe("backpressure / degradation signals", () => {
   });
 });
 
+describe("transport-closed", () => {
+  beforeEach(async () => {
+    document.body.innerHTML = "";
+    await loadTavern();
+  });
+
+  it("fires on SSE error after connection was open", () => {
+    const el = createSSEElement();
+    window.Tavern.bind(el);
+
+    // Establish a connection first
+    simulateSSEOpen(el);
+    expect(el._tavernRegionState).toBe("live");
+
+    const spy = vi.fn();
+    el.addEventListener("tavern:transport-closed", spy);
+
+    el.dispatchEvent(new CustomEvent("htmx:sseError"));
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT fire before first connection (state is connecting)", () => {
+    const el = createSSEElement();
+    window.Tavern.bind(el);
+    expect(el._tavernRegionState).toBe("connecting");
+
+    const spy = vi.fn();
+    el.addEventListener("tavern:transport-closed", spy);
+
+    el.dispatchEvent(new CustomEvent("htmx:sseError"));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("fires BEFORE tavern:disconnected", () => {
+    const el = createSSEElement();
+    window.Tavern.bind(el);
+
+    simulateSSEOpen(el);
+
+    /** @type {string[]} */
+    const order = [];
+    el.addEventListener("tavern:transport-closed", () => order.push("transport-closed"));
+    el.addEventListener("tavern:disconnected", () => order.push("disconnected"));
+
+    el.dispatchEvent(new CustomEvent("htmx:sseError"));
+    expect(order).toEqual(["transport-closed", "disconnected"]);
+  });
+
+  it("forms a symmetric pair with transport-open on reconnect", () => {
+    const el = createSSEElement();
+    window.Tavern.bind(el);
+
+    const source = simulateSSEOpen(el);
+
+    /** @type {string[]} */
+    const events = [];
+    el.addEventListener("tavern:transport-closed", () => events.push("closed"));
+    el.addEventListener("tavern:transport-open", () => events.push("open"));
+
+    // Disconnect
+    el.dispatchEvent(new CustomEvent("htmx:sseError"));
+
+    // Reconnect — transport-open fires when SSE reopens after a disconnect
+    simulateSSEOpen(el, createMockEventSource());
+
+    expect(events).toEqual(["closed", "open"]);
+  });
+
+  it("bubbles", () => {
+    const el = createSSEElement();
+    window.Tavern.bind(el);
+
+    simulateSSEOpen(el);
+
+    const spy = vi.fn();
+    document.body.addEventListener("tavern:transport-closed", spy);
+
+    el.dispatchEvent(new CustomEvent("htmx:sseError"));
+    expect(spy).toHaveBeenCalledOnce();
+
+    document.body.removeEventListener("tavern:transport-closed", spy);
+  });
+});
+
 describe("non-browser environment", () => {
   it("does not crash when document is undefined", async () => {
     const { execSync } = await import("node:child_process");


### PR DESCRIPTION
## Summary

- Add `tavern:transport-closed` event that fires on `htmx:sseError` when a connection was previously established (state is not "connecting")
- Fires before `tavern:disconnected` in the error handler — raw transport fact precedes region state transition
- Forms a symmetric pair with `tavern:transport-open` for diagnostics and shell-level indicators
- Add transport signals section to README with usage example

## Test plan

- [x] `tavern:transport-closed` fires on SSE error after connection was open
- [x] `tavern:transport-closed` does NOT fire before first connection (state is "connecting")
- [x] `tavern:transport-closed` fires BEFORE `tavern:disconnected` (event ordering)
- [x] `tavern:transport-closed` + `tavern:transport-open` form a symmetric pair on reconnect
- [x] Event bubbles
- [x] `npm run check` passes (lint + 125 tests + build)